### PR TITLE
fix: correct command options in get_video_meta_data function

### DIFF
--- a/lada/lib/video_utils.py
+++ b/lada/lib/video_utils.py
@@ -87,7 +87,7 @@ class VideoReader:
         self.container.seek(offset)
 
 def get_video_meta_data(path: str) -> VideoMetadata:
-    cmd = ['ffprobe', '-v', 'quiet', '-output_format', 'json', '-select_streams', 'v', '-show_streams', '-show_format', path]
+    cmd = ['ffprobe', '-v', 'quiet', '-print_format', 'json', '-select_streams', 'v', '-show_streams', '-show_format', path]
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err =  p.communicate()
     if p.returncode != 0:


### PR DESCRIPTION
Updates the `ffprobe` command to use `-print_format` instead of `-output_format`.

This change ensures compatibility with different versions of ffprobe.

## Summary by Sourcery

Bug Fixes:
- Replaced `-output_format` with `-print_format` in ffprobe command to ensure correct metadata extraction